### PR TITLE
fix: widen academic term selector

### DIFF
--- a/apps/web/src/components/academic-term-selector.tsx
+++ b/apps/web/src/components/academic-term-selector.tsx
@@ -76,7 +76,7 @@ export function AcademicTermSelector({ className }: AcademicTermSelectorProps) {
   };
 
   return (
-    <div className={cn("flex w-full md:w-64", className)}>
+    <div className={cn("flex w-full md:w-96", className)}>
       <Select
         onValueChange={(value) => {
           if (value) {

--- a/apps/web/src/components/course/course-filters.tsx
+++ b/apps/web/src/components/course/course-filters.tsx
@@ -103,7 +103,7 @@ export function CourseFilters({ filters, setters }: CourseFiltersProps) {
         </Select>
       </div>
 
-      <AcademicTermSelector className="w-full md:w-64" />
+      <AcademicTermSelector className="w-full md:w-96" />
     </div>
   );
 }


### PR DESCRIPTION
## Description

Widen academic term selectors on medium and larger screens to improve readability and prevent truncated options.

## Type of Change

- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Code style changes (formatting, missing semicolons, etc.)
- [ ] refactor: Code refactoring without changing functionality
- [ ] perf: Performance improvements
- [ ] test: Adding or updating tests
- [ ] chore: Changes to build process, dependencies, or tooling
- [ ] ci: Changes to CI/CD configuration

## Changes Made

- Increased academic term selector width from `md:w-64` to `md:w-96`.
- Applied wider selector styling in both academic term and course filter components.

## Testing

- [ ] I have tested this locally
- [ ] I have verified the changes work as expected
- [ ] I have checked for any console errors or warnings

## Checklist

- [ ] My code follows the project's code style (Ultracite standards)
- [ ] I have run `bun run fix` and it passes
- [ ] I have run `bun run check-types` and it passes
- [ ] I have run `bun run build` and it succeeds
- [ ] I have removed all `console.log` and `debugger` statements
- [x] I have used explicit TypeScript types (no `any`)
- [x] My changes are properly typed
- [ ] I have updated documentation if needed
- [x] My commit message follows the conventional commit format
- [ ] I have tested in the relevant environment (browser, etc.)

## Related Issues

Closes #

## Screenshots / Demo

Not applicable.

## Additional Notes

Width remains full on small screens and expands to `md:w-96` on medium and larger screens.