### PR TITLE
feat(schedule): add configurable display range

### DIFF
--- a/apps/web/src/components/course/vaul/form.tsx
+++ b/apps/web/src/components/course/vaul/form.tsx
@@ -29,7 +29,7 @@ import {
   TagsInputItem,
   TagsInputList,
 } from "@/components/ui/tags-input";
-import { DAYS } from "@/constants/times";
+import { DAYS, getFullDayTimeSlots } from "@/constants/times";
 import { parseTime } from "@/lib/parser/time";
 import { useSelectedGenElectivesActions } from "@/stores/selected";
 
@@ -56,16 +56,7 @@ export function CourseVaulForm() {
   const { updateSession } = useSelectedGenElectivesActions();
   const { setIsEditing, session } = useCourseVaulContext();
 
-  const timeSlots = useMemo(() => {
-    const slots: string[] = [];
-    for (let hour = 8; hour <= 18; hour++) {
-      slots.push(`${hour.toString().padStart(2, "0")}:00`);
-      if (hour < 18) {
-        slots.push(`${hour.toString().padStart(2, "0")}:30`);
-      }
-    }
-    return slots;
-  }, []);
+  const timeSlots = useMemo(getFullDayTimeSlots, []);
 
   const form = useForm({
     defaultValues: {
@@ -255,7 +246,7 @@ export function CourseVaulForm() {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {timeSlots.map((time) => {
+                      {timeSlots.slice(0, -1).map((time) => {
                         const isDisabled = endTime
                           ? parseTime(time) >= parseTime(endTime)
                           : false;
@@ -303,7 +294,7 @@ export function CourseVaulForm() {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {timeSlots.map((time) => {
+                      {timeSlots.slice(1).map((time) => {
                         const isDisabled = startTime
                           ? parseTime(time) <= parseTime(startTime)
                           : false;

--- a/apps/web/src/components/schedule/block.tsx
+++ b/apps/web/src/components/schedule/block.tsx
@@ -27,6 +27,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import type { ScheduleTimeRange } from "@/constants/times";
+import { parseTime } from "@/lib/parser/time";
 import type { SelectedClassSession } from "@/stores/selected";
 import { useSelectedGenElectivesActions } from "@/stores/selected";
 
@@ -40,6 +42,7 @@ interface SessionBlockProps {
   textClass?: string;
   subTextClass?: string;
   defaultEditMode?: boolean;
+  timeRange: ScheduleTimeRange;
 }
 
 export function SessionBlock({
@@ -51,13 +54,23 @@ export function SessionBlock({
   textClass = "text-xs",
   subTextClass = "text-[10px]",
   defaultEditMode = false,
+  timeRange,
 }: SessionBlockProps) {
-  const { startOffset, span } = getTimeSlotPosition(session.start, session.end);
+  const position = getTimeSlotPosition(session.start, session.end, timeRange);
   const classKey = getClassKey(session);
   const hasOverlapping = hasOverlap(session, allSessions);
   const overlappingSessions = getOverlappingSessions(session, allSessions);
   const { remove } = useSelectedGenElectivesActions();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const { t } = useTranslation();
+
+  if (!position) {
+    return null;
+  }
+
+  const { startOffset, span } = position;
+  const durationHours =
+    (parseTime(session.end) - parseTime(session.start)) / 60;
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -70,8 +83,6 @@ export function SessionBlock({
     remove(session.id);
     setShowDeleteDialog(false);
   };
-
-  const { t } = useTranslation();
 
   return (
     <ContextMenu>
@@ -123,7 +134,7 @@ export function SessionBlock({
                   : "text-primary-foreground/80"
               }`}
             >
-              {session.start} - {session.end} ({span}h)
+              {session.start} - {session.end} ({durationHours}h)
             </div>
           </div>
         </CourseVaul>

--- a/apps/web/src/components/schedule/draggable-block.tsx
+++ b/apps/web/src/components/schedule/draggable-block.tsx
@@ -1,6 +1,7 @@
 import { useDraggable } from "@dnd-kit/core";
 import { GripVertical } from "lucide-react";
 import { getClassKey, getTimeSlotPosition } from "@/components/schedule/utils";
+import type { ScheduleTimeRange } from "@/constants/times";
 import type { SelectedClassSession } from "@/stores/selected";
 import { SessionBlock } from "./block";
 
@@ -17,6 +18,7 @@ interface DraggableBlockProps {
   textClass?: string;
   subTextClass?: string;
   defaultEditMode?: boolean;
+  timeRange: ScheduleTimeRange;
 }
 
 export function DraggableBlock({
@@ -29,11 +31,12 @@ export function DraggableBlock({
   textClass,
   subTextClass,
   defaultEditMode = false,
+  timeRange,
 }: DraggableBlockProps) {
   const classKey = getClassKey(session);
   const isCustom = session.type === "custom";
-  const { startOffset, span } = getTimeSlotPosition(session.start, session.end);
-  const isSmallBlock = span < 1;
+  const position = getTimeSlotPosition(session.start, session.end, timeRange);
+  const isSmallBlock = position ? position.span < 1 : false;
 
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: classKey,
@@ -42,6 +45,12 @@ export function DraggableBlock({
       session,
     },
   });
+
+  if (!position) {
+    return null;
+  }
+
+  const { startOffset, span } = position;
 
   const handleResizePointerDown = (
     e: React.PointerEvent,
@@ -118,6 +127,7 @@ export function DraggableBlock({
         session={session}
         subTextClass={subTextClass}
         textClass={textClass}
+        timeRange={timeRange}
       />
     </div>
   );

--- a/apps/web/src/components/schedule/export/export-dialog.tsx
+++ b/apps/web/src/components/schedule/export/export-dialog.tsx
@@ -32,6 +32,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import type { AcademicTerm } from "@/course/academic-term";
 import { cn } from "@/lib/utils";
+import { useScheduleTimeRange } from "@/stores/schedule-settings";
 import type { SelectedClassSession } from "@/stores/selected";
 import { SchedulePreview } from "./schedule-preview";
 import {
@@ -53,6 +54,7 @@ export function ScheduleExportDialog({
   triggerClassName,
 }: ScheduleExportDialogProps) {
   const { t } = useTranslation();
+  const timeRange = useScheduleTimeRange();
 
   const [format, setFormat] = useState<ExportFormat>("png");
   const [darkMode, setDarkMode] = useState(false);
@@ -192,6 +194,7 @@ export function ScheduleExportDialog({
                       sessions={sessions}
                       shorthand={isShorthand}
                       term={term}
+                      timeRange={timeRange}
                     />
                   </div>
                 </div>
@@ -456,6 +459,7 @@ export function ScheduleExportDialog({
                 sessions={sessions}
                 shorthand={isShorthand}
                 term={term}
+                timeRange={timeRange}
               />
             </div>
           </div>

--- a/apps/web/src/components/schedule/export/schedule-preview.tsx
+++ b/apps/web/src/components/schedule/export/schedule-preview.tsx
@@ -7,7 +7,11 @@ import {
   isFirstCol,
 } from "@/components/schedule/utils";
 import { SCHEDULE_SIZE } from "@/constants/schedule";
-import { DAYS, TIME_SLOTS } from "@/constants/times";
+import {
+  DAYS,
+  getScheduleTimeSlots,
+  type ScheduleTimeRange,
+} from "@/constants/times";
 import type { AcademicTerm } from "@/course/academic-term";
 import { cn } from "@/lib/utils";
 import { useScheduleSize } from "@/stores/schedule-settings";
@@ -18,6 +22,7 @@ interface SchedulePreviewProps {
   term: AcademicTerm;
   darkMode: boolean;
   shorthand: boolean;
+  timeRange: ScheduleTimeRange;
 }
 
 export function SchedulePreview({
@@ -25,11 +30,13 @@ export function SchedulePreview({
   term,
   darkMode,
   shorthand,
+  timeRange,
 }: SchedulePreviewProps) {
   const { t } = useTranslation();
   const size = useScheduleSize();
   const { cellSize, dayColumnWidth, rowHeight, textClass, subTextClass } =
     SCHEDULE_SIZE[size];
+  const timeSlots = getScheduleTimeSlots(timeRange);
 
   // Calculate scaled dimensions
   const scaledCellSize = cellSize;
@@ -56,7 +63,7 @@ export function SchedulePreview({
       <div
         className={cn("grid border", borderClass)}
         style={{
-          gridTemplateColumns: `${scaledDayColumnWidth}px repeat(${TIME_SLOTS.length}, ${scaledCellSize}px)`,
+          gridTemplateColumns: `${scaledDayColumnWidth}px repeat(${timeSlots.length}, ${scaledCellSize}px)`,
         }}
       >
         <div
@@ -69,7 +76,7 @@ export function SchedulePreview({
         >
           {t("days_time.day")}
         </div>
-        {TIME_SLOTS.map((time) => (
+        {timeSlots.map((time) => (
           <div
             className={cn(
               "flex items-center justify-center border-r p-2 text-center font-medium text-xs last:border-r-0",
@@ -99,14 +106,15 @@ export function SchedulePreview({
                 : t(`days_time.${day.toLowerCase()}`)}
             </div>
 
-            {TIME_SLOTS.map((_time, timeColIndex) => {
+            {timeSlots.map((_time, timeColIndex) => {
               const cellClasses = getClassesForCell(
                 day,
                 timeColIndex,
-                sessions
+                sessions,
+                timeRange
               );
               const firstColClasses = cellClasses.filter((session) =>
-                isFirstCol(session, timeColIndex)
+                isFirstCol(session, timeColIndex, timeRange)
               );
 
               return (
@@ -122,10 +130,17 @@ export function SchedulePreview({
                 >
                   {firstColClasses.map((session) => {
                     const classKey = getClassKey(session);
-                    const { startOffset, span } = getTimeSlotPosition(
+                    const position = getTimeSlotPosition(
                       session.start,
-                      session.end
+                      session.end,
+                      timeRange
                     );
+
+                    if (!position) {
+                      return null;
+                    }
+
+                    const { startOffset, span } = position;
 
                     const isOverlapping = hasOverlap(session, sessions);
                     // For basic export check we use global session check.

--- a/apps/web/src/components/schedule/index.tsx
+++ b/apps/web/src/components/schedule/index.tsx
@@ -34,11 +34,14 @@ import {
   SCHEDULE_SIZE,
   SLOT_DURATION_MINUTES,
 } from "@/constants/schedule";
-import { DAYS, TIME_SLOTS } from "@/constants/times";
+import { DAYS, getScheduleTimeSlots } from "@/constants/times";
 import type { AcademicTerm } from "@/course/academic-term";
 import type { GenElectiveOption } from "@/course/schema";
 import { cn } from "@/lib/utils";
-import { useScheduleSize } from "@/stores/schedule-settings";
+import {
+  useScheduleSize,
+  useScheduleTimeRange,
+} from "@/stores/schedule-settings";
 import {
   type SelectedClassSession,
   useSelectedGenElectivesActions,
@@ -106,9 +109,11 @@ function DroppableCell({
 
 export function Schedule({ sessions, term, styles }: ScheduleProps) {
   const size = useScheduleSize();
+  const timeRange = useScheduleTimeRange();
+  const timeSlots = getScheduleTimeSlots(timeRange);
   const { cellSize, dayColumnWidth, rowHeight, textClass, subTextClass } =
     SCHEDULE_SIZE[size];
-  const minWidth = dayColumnWidth + TIME_SLOTS.length * cellSize + 2;
+  const minWidth = dayColumnWidth + timeSlots.length * cellSize + 2;
   const { t } = useTranslation();
 
   const [openClassKey, setOpenClassKey] = useState<string | null>(null);
@@ -159,7 +164,8 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
       const dayRowInfo = findDayRowFromMousePosition(
         e,
         cellSize,
-        dayColumnWidth
+        dayColumnWidth,
+        timeRange
       );
       if (!dayRowInfo || dayRowInfo.day !== resizeState.session.day) {
         return;
@@ -169,30 +175,30 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
       const { slotIndex } = get30MinuteSlotFromPosition(
         cellX,
         cellSize,
-        timeColIndex
+        timeColIndex,
+        timeRange
       );
 
       const { newStart, newEnd } = calculateResizePreview(
         resizeState.session,
         resizeState.edge,
-        slotIndex
+        slotIndex,
+        timeRange
       );
 
-      const { startCol, startOffset, span } = getTimeSlotPosition(
-        newStart,
-        newEnd
-      );
+      const position = getTimeSlotPosition(newStart, newEnd, timeRange);
+      if (!position) {
+        return;
+      }
 
       setResizePreview({
         session: resizeState.session,
         start: newStart,
         end: newEnd,
-        startCol,
-        startOffset,
-        span,
+        ...position,
       });
     },
-    [resizeState, cellSize, dayColumnWidth]
+    [resizeState, cellSize, dayColumnWidth, timeRange]
   );
 
   const handleResizePointerUp = useCallback(() => {
@@ -236,18 +242,17 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
       originalEnd: session.end,
     });
 
-    const { startCol, startOffset, span } = getTimeSlotPosition(
-      session.start,
-      session.end
-    );
+    const position = getTimeSlotPosition(session.start, session.end, timeRange);
+
+    if (!position) {
+      return;
+    }
 
     setResizePreview({
       session,
       start: session.start,
       end: session.end,
-      startCol,
-      startOffset,
-      span,
+      ...position,
     });
   };
 
@@ -260,7 +265,8 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
       const dayRowInfo = findDayRowFromMousePosition(
         e,
         cellSize,
-        dayColumnWidth
+        dayColumnWidth,
+        timeRange
       );
 
       if (!dayRowInfo) {
@@ -273,27 +279,28 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
       const { slotIndex } = get30MinuteSlotFromPosition(
         cellX,
         cellSize,
-        timeColIndex
+        timeColIndex,
+        timeRange
       );
 
       const { newStart, newEnd } = calculateSnappedPreview(
         activeSession,
         day as GenElectiveOption["class"][number]["day"],
-        slotIndex
+        slotIndex,
+        timeRange
       );
 
-      const { startCol, startOffset, span } = getTimeSlotPosition(
-        newStart,
-        newEnd
-      );
+      const position = getTimeSlotPosition(newStart, newEnd, timeRange);
+      if (!position) {
+        setSnappedPreview(null);
+        return;
+      }
 
       setSnappedPreview({
         day: day as GenElectiveOption["class"][number]["day"],
         start: newStart,
         end: newEnd,
-        startCol,
-        startOffset,
-        span,
+        ...position,
       });
       setDragOverPosition({ x: e.clientX, y: e.clientY });
     };
@@ -303,7 +310,7 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     return () => {
       document.removeEventListener("pointermove", handleGlobalPointerMove);
     };
-  }, [activeSession, cellSize, dayColumnWidth]);
+  }, [activeSession, cellSize, dayColumnWidth, timeRange]);
 
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event;
@@ -336,27 +343,28 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     const { slotIndex } = get30MinuteSlotFromPosition(
       position.cellX,
       cellSize,
-      timeColIndex
+      timeColIndex,
+      timeRange
     );
 
     const { newStart, newEnd } = calculateSnappedPreview(
       sessionData,
       day as GenElectiveOption["class"][number]["day"],
-      slotIndex
+      slotIndex,
+      timeRange
     );
 
-    const { startCol, startOffset, span } = getTimeSlotPosition(
-      newStart,
-      newEnd
-    );
+    const positionPreview = getTimeSlotPosition(newStart, newEnd, timeRange);
+    if (!positionPreview) {
+      setSnappedPreview(null);
+      return;
+    }
 
     setSnappedPreview({
       day: day as GenElectiveOption["class"][number]["day"],
       start: newStart,
       end: newEnd,
-      startCol,
-      startOffset,
-      span,
+      ...positionPreview,
     });
   };
 
@@ -383,7 +391,8 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     const { slotIndex } = get30MinuteSlotFromPosition(
       position.cellX,
       cellSize,
-      timeColIndex
+      timeColIndex,
+      timeRange
     );
 
     const startSlot = Math.min(dragState.startSlot, slotIndex);
@@ -461,13 +470,15 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     const { slotIndex } = get30MinuteSlotFromPosition(
       position.cellX,
       cellSize,
-      timeColIndex
+      timeColIndex,
+      timeRange
     );
 
     const result = calculateSnappedPreview(
       sessionData,
       day as GenElectiveOption["class"][number]["day"],
-      slotIndex
+      slotIndex,
+      timeRange
     );
 
     return {
@@ -579,7 +590,8 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     const { slotIndex } = get30MinuteSlotFromPosition(
       x,
       cellSize,
-      timeColIndex
+      timeColIndex,
+      timeRange
     );
 
     dragStartRef.current = { day, timeColIndex, x };
@@ -609,7 +621,7 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     }
 
     const timeColIndex = Math.floor(x / cellSize);
-    if (timeColIndex < 0 || timeColIndex >= TIME_SLOTS.length) {
+    if (timeColIndex < 0 || timeColIndex >= timeSlots.length) {
       return;
     }
 
@@ -617,7 +629,8 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     const { slotIndex } = get30MinuteSlotFromPosition(
       cellX,
       cellSize,
-      timeColIndex
+      timeColIndex,
+      timeRange
     );
 
     const startSlot = Math.min(dragState.startSlot, slotIndex);
@@ -653,8 +666,8 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
     const duration = (endSlot - startSlot) * SLOT_DURATION_MINUTES;
 
     if (duration >= MIN_DRAG_DURATION) {
-      const startTime = getTimeFrom30MinuteSlot(startSlot);
-      const endTime = getTimeFrom30MinuteSlot(endSlot + 1);
+      const startTime = getTimeFrom30MinuteSlot(startSlot, timeRange);
+      const endTime = getTimeFrom30MinuteSlot(endSlot + 1, timeRange);
       const createdSession = addCustom(term, dragState.day, startTime, endTime);
 
       if (createdSession) {
@@ -680,13 +693,13 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
         <div
           className={cn("grid border border-border", styles?.borderTop)}
           style={{
-            gridTemplateColumns: `${dayColumnWidth}px repeat(${TIME_SLOTS.length}, ${cellSize}px)`,
+            gridTemplateColumns: `${dayColumnWidth}px repeat(${timeSlots.length}, ${cellSize}px)`,
           }}
         >
           <div className="sticky left-0 z-10 border-border border-r bg-muted p-2 text-center font-medium text-muted-foreground text-xs">
             {t("days_time.day")}
           </div>
-          {TIME_SLOTS.map((time) => (
+          {timeSlots.map((time) => (
             <div
               className="border-border border-r bg-muted/50 p-2 text-center font-medium text-muted-foreground text-xs last:border-r-0"
               key={time}
@@ -714,7 +727,7 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
               onPointerMove={handlePointerMove}
               onPointerUp={handlePointerUp}
               style={{
-                gridTemplateColumns: `${dayColumnWidth}px repeat(${TIME_SLOTS.length}, ${cellSize}px)`,
+                gridTemplateColumns: `${dayColumnWidth}px repeat(${timeSlots.length}, ${cellSize}px)`,
               }}
             >
               <div
@@ -723,14 +736,15 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
               >
                 {t(`days_short.${day.toLowerCase()}`)}
               </div>
-              {TIME_SLOTS.map((time, timeColIndex) => {
+              {timeSlots.map((time, timeColIndex) => {
                 const cellClasses = getClassesForCell(
                   day,
                   timeColIndex,
-                  sessions
+                  sessions,
+                  timeRange
                 );
                 const firstColClasses = cellClasses.filter((session) =>
-                  isFirstCol(session, timeColIndex)
+                  isFirstCol(session, timeColIndex, timeRange)
                 );
                 const dropId = `${day}-${timeColIndex}`;
 
@@ -773,6 +787,7 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
                             session={session}
                             subTextClass={subTextClass}
                             textClass={textClass}
+                            timeRange={timeRange}
                           />
                         ) : (
                           <SessionBlock
@@ -783,6 +798,7 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
                             session={session}
                             subTextClass={subTextClass}
                             textClass={textClass}
+                            timeRange={timeRange}
                           />
                         );
                       })}
@@ -832,18 +848,27 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
                             dragState.startSlot,
                             dragState.endSlot
                           );
-                          const startTime = getTimeFrom30MinuteSlot(startSlot);
-                          const endTime = getTimeFrom30MinuteSlot(endSlot + 1);
-                          const { startCol, startOffset, span } =
-                            getTimeSlotPosition(startTime, endTime);
+                          const startTime = getTimeFrom30MinuteSlot(
+                            startSlot,
+                            timeRange
+                          );
+                          const endTime = getTimeFrom30MinuteSlot(
+                            endSlot + 1,
+                            timeRange
+                          );
+                          const position = getTimeSlotPosition(
+                            startTime,
+                            endTime,
+                            timeRange
+                          );
 
-                          if (timeColIndex === startCol) {
+                          if (position && timeColIndex === position.startCol) {
                             return (
                               <div
                                 className={`absolute inset-y-0 z-30 m-0.5 select-none rounded border border-primary border-dashed bg-primary/20 p-1.5 ${textClass}`}
                                 style={{
-                                  left: `${startOffset * 100}%`,
-                                  width: `calc(${span * 100}% - 0.25rem)`,
+                                  left: `${position.startOffset * 100}%`,
+                                  width: `calc(${position.span * 100}% - 0.25rem)`,
                                 }}
                               >
                                 <div className="min-w-0">

--- a/apps/web/src/components/schedule/settings/settings-registry.tsx
+++ b/apps/web/src/components/schedule/settings/settings-registry.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { SizeSelector } from "./size-selector";
+import { TimeRangeSelector } from "./time-range-selector";
 
 export interface SettingItem {
   id: string;
@@ -27,6 +28,18 @@ export function getSettingsRegistry(
           label: t("settings.size"),
           keywords: ["size", "scale", "dimension", "width", "height", "layout"],
           render: () => <SizeSelector />,
+        },
+      ],
+    },
+    {
+      id: "schedule",
+      header: "settings.group.schedule",
+      items: [
+        {
+          id: "time-range",
+          label: t("settings.time_range"),
+          keywords: ["time", "range", "hour", "hours", "schedule", "grid"],
+          render: () => <TimeRangeSelector />,
         },
       ],
     },

--- a/apps/web/src/components/schedule/settings/time-range-selector.tsx
+++ b/apps/web/src/components/schedule/settings/time-range-selector.tsx
@@ -1,0 +1,65 @@
+import { useTranslation } from "react-i18next";
+import { RangeSlider } from "@/components/ui/slider";
+import {
+  formatScheduleHour,
+  SCHEDULE_TIME_RANGE_LIMITS,
+} from "@/constants/times";
+import {
+  useScheduleSettingsActions,
+  useScheduleTimeRange,
+} from "@/stores/schedule-settings";
+
+export function TimeRangeSelector() {
+  const { t } = useTranslation();
+  const timeRange = useScheduleTimeRange();
+  const { setTimeRange } = useScheduleSettingsActions();
+
+  const value: readonly [number, number] = [
+    timeRange.startHour,
+    timeRange.endHour,
+  ];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <span className="text-muted-foreground">
+          {t("settings.time_range")}
+        </span>
+        <span className="font-medium tabular-nums">
+          {formatScheduleHour(timeRange.startHour)} –{" "}
+          {formatScheduleHour(timeRange.endHour)}
+        </span>
+      </div>
+      <RangeSlider
+        getAriaLabel={(index) =>
+          index === 0
+            ? t("settings.time_range_start_aria")
+            : t("settings.time_range_end_aria")
+        }
+        getAriaValueText={(_formattedValue, value, index) =>
+          `${index === 0 ? t("settings.time_range_start") : t("settings.time_range_end")}: ${formatScheduleHour(value)}`
+        }
+        max={SCHEDULE_TIME_RANGE_LIMITS.maxHour}
+        min={SCHEDULE_TIME_RANGE_LIMITS.minHour}
+        minStepsBetweenValues={SCHEDULE_TIME_RANGE_LIMITS.minDurationHours}
+        onValueChange={(nextValue) => {
+          const [startHour, endHour] = nextValue;
+          if (
+            typeof startHour === "number" &&
+            typeof endHour === "number" &&
+            endHour - startHour >= SCHEDULE_TIME_RANGE_LIMITS.minDurationHours
+          ) {
+            setTimeRange({ startHour, endHour });
+          }
+        }}
+        step={1}
+        thumbCollisionBehavior="none"
+        value={value}
+      />
+      <div className="flex justify-between text-muted-foreground text-xs tabular-nums">
+        <span>{formatScheduleHour(SCHEDULE_TIME_RANGE_LIMITS.minHour)}</span>
+        <span>{formatScheduleHour(SCHEDULE_TIME_RANGE_LIMITS.maxHour)}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/schedule/utils.ts
+++ b/apps/web/src/components/schedule/utils.ts
@@ -1,32 +1,92 @@
-import { BASE_MINUTES, SLOT_DURATION_MINUTES } from "@/constants/schedule";
-import { DAYS, TIME_SLOTS } from "@/constants/times";
+import { SLOT_DURATION_MINUTES } from "@/constants/schedule";
+import {
+  DAYS,
+  DEFAULT_SCHEDULE_TIME_RANGE,
+  getScheduleTimeSlots,
+  normalizeScheduleTimeRange,
+  type ScheduleTimeRange,
+} from "@/constants/times";
 import type { GenElectiveOption } from "@/course/schema";
 import { parseTime } from "@/lib/parser/time";
 import type { SelectedClassSession } from "@/stores/selected";
 
-export function getTimeSlotPosition(
-  start: string,
-  end: string
-): {
+export interface TimeSlotPosition {
   startCol: number;
   startOffset: number;
   span: number;
   endOffset: number;
-} {
+}
+
+interface VisibleSessionInterval {
+  startMinutes: number;
+  endMinutes: number;
+}
+
+function formatMinutes(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+}
+
+export function getVisibleSessionInterval(
+  start: string,
+  end: string,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
+): VisibleSessionInterval | null {
+  const normalizedRange = normalizeScheduleTimeRange(range);
   const startMinutes = parseTime(start);
   const endMinutes = parseTime(end);
-  const baseMinutes = BASE_MINUTES;
+  const rangeStartMinutes = normalizedRange.startHour * 60;
+  const rangeEndMinutes = normalizedRange.endHour * 60;
 
-  const startCol = Math.floor((startMinutes - baseMinutes) / 60);
-  const startOffset = ((startMinutes - baseMinutes) % 60) / 60;
+  if (
+    !(Number.isFinite(startMinutes) && Number.isFinite(endMinutes)) ||
+    startMinutes >= endMinutes
+  ) {
+    return null;
+  }
 
-  const endCol = Math.floor((endMinutes - baseMinutes) / 60);
-  const endOffset = ((endMinutes - baseMinutes) % 60) / 60;
+  const visibleStartMinutes = Math.max(startMinutes, rangeStartMinutes);
+  const visibleEndMinutes = Math.min(endMinutes, rangeEndMinutes);
 
+  if (visibleStartMinutes >= visibleEndMinutes) {
+    return null;
+  }
+
+  return {
+    startMinutes: visibleStartMinutes,
+    endMinutes: visibleEndMinutes,
+  };
+}
+
+export function getTimeSlotPosition(
+  start: string,
+  end: string,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
+): TimeSlotPosition | null {
+  const normalizedRange = normalizeScheduleTimeRange(range);
+  const visibleInterval = getVisibleSessionInterval(
+    start,
+    end,
+    normalizedRange
+  );
+
+  if (!visibleInterval) {
+    return null;
+  }
+
+  const rangeStartMinutes = normalizedRange.startHour * 60;
+  const relativeStartMinutes = visibleInterval.startMinutes - rangeStartMinutes;
+  const relativeEndMinutes = visibleInterval.endMinutes - rangeStartMinutes;
+
+  const startCol = Math.floor(relativeStartMinutes / 60);
+  const startOffset = (relativeStartMinutes % 60) / 60;
+  const endCol = Math.floor(relativeEndMinutes / 60);
+  const endOffset = (relativeEndMinutes % 60) / 60;
   const span = endCol - startCol + (endOffset - startOffset);
 
   return {
-    startCol: Math.max(0, startCol),
+    startCol,
     startOffset,
     span: Math.max(0.5, span),
     endOffset,
@@ -74,20 +134,24 @@ export function getOverlappingSessions(
 export function get30MinuteSlotFromPosition(
   x: number,
   cellWidth: number,
-  timeColIndex: number
+  timeColIndex: number,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
 ): { slotIndex: number; time: string } {
   const xPercent = x / cellWidth;
   const halfSlot = xPercent < 0.5 ? 0 : 1;
   const slotIndex = timeColIndex * 2 + halfSlot;
-  const time = getTimeFrom30MinuteSlot(slotIndex);
+  const time = getTimeFrom30MinuteSlot(slotIndex, range);
   return { slotIndex, time };
 }
 
-export function getTimeFrom30MinuteSlot(slotIndex: number): string {
-  const totalMinutes = BASE_MINUTES + slotIndex * SLOT_DURATION_MINUTES;
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+export function getTimeFrom30MinuteSlot(
+  slotIndex: number,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
+): string {
+  const normalizedRange = normalizeScheduleTimeRange(range);
+  const totalMinutes =
+    normalizedRange.startHour * 60 + slotIndex * SLOT_DURATION_MINUTES;
+  return formatMinutes(totalMinutes);
 }
 
 export function formatTimeRange(start: string, end: string): string {
@@ -97,32 +161,30 @@ export function formatTimeRange(start: string, end: string): string {
 export function calculateSnappedPreview(
   session: SelectedClassSession,
   _targetDay: GenElectiveOption["class"][number]["day"],
-  targetSlotIndex: number
+  targetSlotIndex: number,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
 ): { newStart: string; newEnd: string } {
   const startMinutes = parseTime(session.start);
   const endMinutes = parseTime(session.end);
   const duration = endMinutes - startMinutes;
-
+  const normalizedRange = normalizeScheduleTimeRange(range);
   const newStartMinutes =
-    BASE_MINUTES + targetSlotIndex * SLOT_DURATION_MINUTES;
-  const newEndMinutes = newStartMinutes + duration;
+    normalizedRange.startHour * 60 + targetSlotIndex * SLOT_DURATION_MINUTES;
 
-  const newStartHours = Math.floor(newStartMinutes / 60);
-  const newStartMins = newStartMinutes % 60;
-  const newEndHours = Math.floor(newEndMinutes / 60);
-  const newEndMins = newEndMinutes % 60;
-
-  const newStart = `${newStartHours.toString().padStart(2, "0")}:${newStartMins.toString().padStart(2, "0")}`;
-  const newEnd = `${newEndHours.toString().padStart(2, "0")}:${newEndMins.toString().padStart(2, "0")}`;
-
-  return { newStart, newEnd };
+  return {
+    newStart: formatMinutes(newStartMinutes),
+    newEnd: formatMinutes(newStartMinutes + duration),
+  };
 }
 
 export function findDayRowFromMousePosition(
   mouseEvent: MouseEvent,
   cellSize: number,
-  dayColumnWidth: number
+  dayColumnWidth: number,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
 ): { day: string; timeColIndex: number; cellX: number } | null {
+  const columnCount = getScheduleTimeSlots(range).length;
+
   for (const day of DAYS) {
     const dayRowElement = document.querySelector(
       `[data-day-row="${day}"]`
@@ -153,7 +215,7 @@ export function findDayRowFromMousePosition(
 
     const timeColIndex = Math.floor(x / cellSize);
 
-    if (timeColIndex < 0 || timeColIndex >= TIME_SLOTS.length) {
+    if (timeColIndex < 0 || timeColIndex >= columnCount) {
       continue;
     }
 
@@ -210,79 +272,70 @@ export function getMousePositionInDayRow(
 export function getClassesForCell(
   day: string,
   timeColIndex: number,
-  sessions: SelectedClassSession[]
+  sessions: SelectedClassSession[],
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
 ): SelectedClassSession[] {
   return sessions.filter((session) => {
     if (session.day !== day) {
       return false;
     }
-    const { startCol, span } = getTimeSlotPosition(session.start, session.end);
-    const endCol = startCol + span;
-    return timeColIndex >= startCol && timeColIndex < Math.ceil(endCol);
+
+    const position = getTimeSlotPosition(session.start, session.end, range);
+    if (!position) {
+      return false;
+    }
+
+    const endCol = position.startCol + position.span;
+    return (
+      timeColIndex >= position.startCol && timeColIndex < Math.ceil(endCol)
+    );
   });
 }
 
 export function isFirstCol(
   session: SelectedClassSession,
-  timeColIndex: number
+  timeColIndex: number,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
 ): boolean {
-  const { startCol } = getTimeSlotPosition(session.start, session.end);
-  return timeColIndex === startCol;
+  const position = getTimeSlotPosition(session.start, session.end, range);
+  return position !== null && timeColIndex === position.startCol;
 }
 
 export function calculateResizePreview(
   session: SelectedClassSession,
   edge: "left" | "right",
-  targetSlotIndex: number
+  targetSlotIndex: number,
+  range: ScheduleTimeRange = DEFAULT_SCHEDULE_TIME_RANGE
 ): { newStart: string; newEnd: string; isValid: boolean } {
   const startMinutes = parseTime(session.start);
   const endMinutes = parseTime(session.end);
   const minDuration = SLOT_DURATION_MINUTES;
+  const normalizedRange = normalizeScheduleTimeRange(range);
+  const rangeStartMinutes = normalizedRange.startHour * 60;
 
   let newStartMinutes = startMinutes;
   let newEndMinutes = endMinutes;
 
   if (edge === "left") {
-    // Left edge = adjusting start time
-    newStartMinutes = BASE_MINUTES + targetSlotIndex * SLOT_DURATION_MINUTES;
+    newStartMinutes =
+      rangeStartMinutes + targetSlotIndex * SLOT_DURATION_MINUTES;
     if (newEndMinutes - newStartMinutes < minDuration) {
       newStartMinutes = newEndMinutes - minDuration;
     }
   } else {
-    // Right edge = adjusting end time
     newEndMinutes =
-      BASE_MINUTES + (targetSlotIndex + 1) * SLOT_DURATION_MINUTES;
+      rangeStartMinutes + (targetSlotIndex + 1) * SLOT_DURATION_MINUTES;
     if (newEndMinutes - newStartMinutes < minDuration) {
       newEndMinutes = newStartMinutes + minDuration;
     }
   }
 
-  const minTime = BASE_MINUTES;
-  const maxTime = BASE_MINUTES + TIME_SLOTS.length * 60;
-
-  const isValid =
-    newStartMinutes >= minTime &&
-    newEndMinutes <= maxTime &&
-    newStartMinutes < newEndMinutes;
-
-  newStartMinutes = Math.max(
-    minTime,
-    Math.min(newStartMinutes, maxTime - minDuration)
-  );
-  newEndMinutes = Math.min(
-    maxTime,
-    Math.max(newEndMinutes, minTime + minDuration)
-  );
-
-  const formatTime = (mins: number) => {
-    const hours = Math.floor(mins / 60);
-    const minutes = mins % 60;
-    return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
-  };
-
   return {
-    newStart: formatTime(newStartMinutes),
-    newEnd: formatTime(newEndMinutes),
-    isValid,
+    newStart: formatMinutes(newStartMinutes),
+    newEnd: formatMinutes(newEndMinutes),
+    isValid:
+      Number.isFinite(newStartMinutes) &&
+      Number.isFinite(newEndMinutes) &&
+      newStartMinutes < newEndMinutes,
   };
 }

--- a/apps/web/src/components/ui/slider.tsx
+++ b/apps/web/src/components/ui/slider.tsx
@@ -1,0 +1,59 @@
+import { Slider as BaseSlider } from "@base-ui/react/slider";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+type BaseSliderProps = React.ComponentProps<typeof BaseSlider.Root>;
+
+interface RangeSliderProps
+  extends Omit<
+    BaseSliderProps,
+    "children" | "defaultValue" | "onValueChange" | "value"
+  > {
+  value: readonly [number, number];
+  onValueChange?: (value: readonly number[]) => void;
+  getAriaLabel?: (index: number) => string;
+  getAriaValueText?: (
+    formattedValue: string,
+    value: number,
+    index: number
+  ) => string;
+}
+
+export function RangeSlider({
+  className,
+  getAriaLabel,
+  getAriaValueText,
+  onValueChange,
+  value,
+  ...props
+}: RangeSliderProps) {
+  return (
+    <BaseSlider.Root
+      {...props}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className
+      )}
+      onValueChange={onValueChange}
+      value={value}
+    >
+      <BaseSlider.Control className="relative flex h-5 w-full items-center">
+        <BaseSlider.Track className="relative h-1.5 w-full grow overflow-visible rounded-full bg-muted">
+          <BaseSlider.Indicator className="absolute h-full rounded-full bg-primary" />
+          <BaseSlider.Thumb
+            className="block size-4 rounded-full border border-primary bg-background shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+            getAriaLabel={getAriaLabel}
+            getAriaValueText={getAriaValueText}
+            index={0}
+          />
+          <BaseSlider.Thumb
+            className="block size-4 rounded-full border border-primary bg-background shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+            getAriaLabel={getAriaLabel}
+            getAriaValueText={getAriaValueText}
+            index={1}
+          />
+        </BaseSlider.Track>
+      </BaseSlider.Control>
+    </BaseSlider.Root>
+  );
+}

--- a/apps/web/src/constants/schedule.ts
+++ b/apps/web/src/constants/schedule.ts
@@ -1,9 +1,5 @@
-import { TIME_SLOTS } from "@/constants/times";
-
 export const CELL_SIZE = 100;
 export const DAY_COLUMN_WIDTH = 56;
-export const MIN_WIDTH = DAY_COLUMN_WIDTH + TIME_SLOTS.length * CELL_SIZE + 2;
-export const BASE_MINUTES = 480;
 export const SLOT_DURATION_MINUTES = 30;
 export const MIN_DRAG_DURATION = 30;
 export const ACTIVATION_DISTANCE = 8;

--- a/apps/web/src/constants/times.ts
+++ b/apps/web/src/constants/times.ts
@@ -7,16 +7,65 @@ export const DAYS = [
   "Saturday",
 ] as const;
 
-export const TIME_SLOTS = [
-  "08:00",
-  "09:00",
-  "10:00",
-  "11:00",
-  "12:00",
-  "13:00",
-  "14:00",
-  "15:00",
-  "16:00",
-  "17:00",
-  "18:00",
-] as const;
+export interface ScheduleTimeRange {
+  startHour: number; // inclusive, 0–23
+  endHour: number; // exclusive, 1–24
+}
+
+export const DEFAULT_SCHEDULE_TIME_RANGE: ScheduleTimeRange = {
+  startHour: 8,
+  endHour: 19,
+};
+
+export const SCHEDULE_TIME_RANGE_LIMITS = {
+  minHour: 0,
+  maxHour: 24,
+  minDurationHours: 1,
+} as const;
+
+export function normalizeScheduleTimeRange(value: unknown): ScheduleTimeRange {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_SCHEDULE_TIME_RANGE;
+  }
+
+  const range = value as Partial<ScheduleTimeRange>;
+  const { startHour, endHour } = range;
+  const isValid =
+    typeof startHour === "number" &&
+    typeof endHour === "number" &&
+    Number.isInteger(startHour) &&
+    Number.isInteger(endHour) &&
+    startHour >= SCHEDULE_TIME_RANGE_LIMITS.minHour &&
+    startHour < SCHEDULE_TIME_RANGE_LIMITS.maxHour &&
+    endHour > SCHEDULE_TIME_RANGE_LIMITS.minHour &&
+    endHour <= SCHEDULE_TIME_RANGE_LIMITS.maxHour &&
+    endHour - startHour >= SCHEDULE_TIME_RANGE_LIMITS.minDurationHours;
+
+  return isValid
+    ? { startHour: startHour as number, endHour: endHour as number }
+    : DEFAULT_SCHEDULE_TIME_RANGE;
+}
+
+export function formatScheduleHour(hour: number): string {
+  return `${hour.toString().padStart(2, "0")}:00`;
+}
+
+export function getScheduleTimeSlots(range: ScheduleTimeRange): string[] {
+  const normalizedRange = normalizeScheduleTimeRange(range);
+
+  return Array.from(
+    { length: normalizedRange.endHour - normalizedRange.startHour },
+    (_, index) => formatScheduleHour(normalizedRange.startHour + index)
+  );
+}
+
+export function getFullDayTimeSlots(): string[] {
+  return Array.from({ length: 49 }, (_, slotIndex) => {
+    const totalMinutes = slotIndex * 30;
+    const hour = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hour.toString().padStart(2, "0")}:${minutes
+      .toString()
+      .padStart(2, "0")}`;
+  });
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -115,8 +115,14 @@
       "size_sm": "Small",
       "size_md": "Medium",
       "size_lg": "Large",
+      "time_range": "Visible time range",
+      "time_range_start": "Start time",
+      "time_range_end": "End time",
+      "time_range_start_aria": "Visible range start time",
+      "time_range_end_aria": "Visible range end time",
       "group": {
-        "appearance": "Appearance"
+        "appearance": "Appearance",
+        "schedule": "Schedule"
       }
     },
     "footer": {

--- a/apps/web/src/locales/th/translation.json
+++ b/apps/web/src/locales/th/translation.json
@@ -115,8 +115,14 @@
       "size_sm": "เล็ก",
       "size_md": "กลาง",
       "size_lg": "ใหญ่",
+      "time_range": "ช่วงเวลาที่แสดง",
+      "time_range_start": "เวลาเริ่มต้น",
+      "time_range_end": "เวลาสิ้นสุด",
+      "time_range_start_aria": "เวลาเริ่มต้นของช่วงที่แสดง",
+      "time_range_end_aria": "เวลาสิ้นสุดของช่วงที่แสดง",
       "group": {
-        "appearance": "รูปแบบตาราง"
+        "appearance": "รูปแบบตาราง",
+        "schedule": "ตารางเรียน"
       }
     },
     "footer": {

--- a/apps/web/src/stores/schedule-settings.ts
+++ b/apps/web/src/stores/schedule-settings.ts
@@ -1,13 +1,44 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import type { SCHEDULE_SIZE } from "@/constants/schedule";
+import { SCHEDULE_SIZE } from "@/constants/schedule";
+import {
+  DEFAULT_SCHEDULE_TIME_RANGE,
+  normalizeScheduleTimeRange,
+  type ScheduleTimeRange,
+} from "@/constants/times";
 
-type ScheduleSize = keyof typeof SCHEDULE_SIZE;
+export type ScheduleSize = keyof typeof SCHEDULE_SIZE;
 
 interface ScheduleSettingsState {
   size: ScheduleSize;
+  timeRange: ScheduleTimeRange;
   actions: {
     setSize: (size: ScheduleSize) => void;
+    setTimeRange: (range: ScheduleTimeRange) => void;
+  };
+}
+
+export type PersistedScheduleSettings = Pick<
+  ScheduleSettingsState,
+  "size" | "timeRange"
+>;
+
+export function migrateScheduleSettings(
+  persistedState: unknown
+): PersistedScheduleSettings {
+  const persisted =
+    persistedState && typeof persistedState === "object"
+      ? (persistedState as Partial<PersistedScheduleSettings>)
+      : {};
+
+  const size =
+    typeof persisted.size === "string" && persisted.size in SCHEDULE_SIZE
+      ? persisted.size
+      : "md";
+
+  return {
+    size,
+    timeRange: normalizeScheduleTimeRange(persisted.timeRange),
   };
 }
 
@@ -15,20 +46,35 @@ const useScheduleSettingsStore = create<ScheduleSettingsState>()(
   persist(
     (set) => ({
       size: "md",
+      timeRange: DEFAULT_SCHEDULE_TIME_RANGE,
       actions: {
         setSize: (size: ScheduleSize) => set({ size }),
+        setTimeRange: (range: ScheduleTimeRange) =>
+          set({ timeRange: normalizeScheduleTimeRange(range) }),
       },
     }),
     {
       name: "schedule-settings-storage",
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ size: state.size }),
+      version: 1,
+      partialize: (state): PersistedScheduleSettings => ({
+        size: state.size,
+        timeRange: state.timeRange,
+      }),
+      migrate: migrateScheduleSettings,
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...migrateScheduleSettings(persistedState),
+      }),
     }
   )
 );
 
 export const useScheduleSize = () =>
   useScheduleSettingsStore((state) => state.size);
+
+export const useScheduleTimeRange = () =>
+  useScheduleSettingsStore((state) => state.timeRange);
 
 export const useScheduleSettingsActions = () =>
   useScheduleSettingsStore((state) => state.actions);

--- a/docs/adr/0001-schedule-display-range.md
+++ b/docs/adr/0001-schedule-display-range.md
@@ -1,0 +1,3 @@
+# Preserve Session Intervals When Clipping Schedule Views
+
+The timetable uses one global, persisted display range for both interactive and visual exports. Sessions are clipped to that range for rendering, but their stored intervals remain unchanged, because a view preference must not rewrite schedule data and the same session must become fully visible when range expands.


### PR DESCRIPTION
## Description

Adds adjustable schedule display hours, allowing users to focus the timetable on a configurable time range.

## Type of Change

- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Code style changes (formatting, missing semicolons, etc.)
- [ ] refactor: Code refactoring without changing functionality
- [ ] perf: Performance improvements
- [ ] test: Adding or updating tests
- [ ] chore: Changes to build process, dependencies, or tooling
- [ ] ci: Changes to CI/CD configuration

## Changes Made

- Added schedule time-range settings with adjustable start and end hours.
- Updated schedule rendering, drag-and-drop, resizing, and custom session creation to respect selected range.
- Updated schedule export previews to use selected range.
- Added time-range slider component and English/Thai translations.
- Added range normalization and visibility handling for sessions outside selected hours.
- Centralized full-day time-slot generation for course forms.
- Recorded schedule display-range decision in ADR documentation.
- Removed obsolete issue screenshot asset.

## Testing

- [ ] I have tested this locally
- [ ] I have verified the changes work as expected
- [ ] I have checked for any console errors or warnings

## Checklist

- [ ] My code follows the project's code style (Ultracite standards)
- [ ] I have run `bun run fix` and it passes
- [ ] I have run `bun run check-types` and it passes
- [ ] I have run `bun run build` and it succeeds
- [ ] I have removed all `console.log` and `debugger` statements
- [ ] I have used explicit TypeScript types (no `any`)
- [ ] My changes are properly typed
- [x] I have updated documentation if needed
- [ ] My commit message follows the conventional commit format
- [ ] I have tested in the relevant environment (browser, etc.)

## Related Issues

Closes #

## Screenshots / Demo

Not applicable.

## Additional Notes

The selected time range is persisted with schedule settings and applies to both the interactive schedule and exported schedule previews.