### PR TITLE
fix(i18n): complete app-owned labels

### DIFF
--- a/apps/web/src/components/course/course-filters.tsx
+++ b/apps/web/src/components/course/course-filters.tsx
@@ -20,11 +20,7 @@ import type {
   CourseFilters as CourseFiltersType,
 } from "@/hooks/use-course-filters";
 
-const TIME_SLOTS = [
-  { label: "All Times", value: "all" },
-  { label: "Morning (before 12:00)", value: "morning" },
-  { label: "Afternoon (12:00+)", value: "afternoon" },
-] as const;
+const TIME_SLOTS = ["all", "morning", "afternoon"] as const;
 
 interface CourseFiltersProps {
   filters: CourseFiltersType;
@@ -96,10 +92,10 @@ export function CourseFilters({ filters, setters }: CourseFiltersProps) {
           </SelectTrigger>
           <SelectContent>
             {TIME_SLOTS.map((slot) => (
-              <SelectItem key={slot.value} value={slot.value}>
-                {slot.value === "all"
+              <SelectItem key={slot} value={slot}>
+                {slot === "all"
                   ? t("filter.times.all")
-                  : t(`filter.times.${slot.value}`)}
+                  : t(`filter.times.${slot}`)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/components/course/vaul/content.tsx
+++ b/apps/web/src/components/course/vaul/content.tsx
@@ -71,7 +71,7 @@ export function CourseVaulContent() {
           </div>
           {session.type === "custom" && (
             <Button
-              aria-label="Edit course information"
+              aria-label={t("course.edit")}
               onClick={() => {
                 setIsEditing(true);
               }}
@@ -141,7 +141,7 @@ export function CourseVaulContent() {
 
       {overlappingSessions.length > 0 && (
         <div className="space-y-2">
-          <div className="font-medium text-sm">Overlaps:</div>
+          <div className="font-medium text-sm">{t("course.overlaps")}</div>
           <div className="flex flex-wrap gap-2">
             {overlappingSessions.map((overlapSession) => {
               const overlapKey = `${overlapSession.courseCode}-${overlapSession.group}-${overlapSession.day}-${overlapSession.start}-${overlapSession.end}`;

--- a/apps/web/src/components/course/vaul/form.tsx
+++ b/apps/web/src/components/course/vaul/form.tsx
@@ -35,30 +35,39 @@ import { DAYS, getFullDayTimeSlots } from "@/constants/times";
 import { parseTime } from "@/lib/parser/time";
 import { useSelectedGenElectivesActions } from "@/stores/selected";
 
-const editSchema = z.object({
-  courseCode: z.string().min(1, "Course code is required."),
-  courseName: z.string().min(1, "Course name is required."),
-  day: z.enum([
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday",
-    "Sunday",
-  ]),
-  endTime: z.string().min(1, "End time is required."),
-  group: z.string().min(1, "Group is required."),
-  instructor: z.array(z.string()).min(1, "At least one instructor is required"),
-  startTime: z.string().min(1, "Start time is required."),
-});
-
 export function CourseVaulForm() {
   const { t } = useTranslation();
   const { updateSession } = useSelectedGenElectivesActions();
   const { setIsEditing, session } = useCourseVaulContext();
 
   const timeSlots = useMemo(() => getFullDayTimeSlots(), []);
+  const editSchema = useMemo(
+    () =>
+      z.object({
+        courseCode: z
+          .string()
+          .min(1, t("form.validation.course_code_required")),
+        courseName: z
+          .string()
+          .min(1, t("form.validation.course_name_required")),
+        day: z.enum([
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sunday",
+        ]),
+        endTime: z.string().min(1, t("form.validation.end_time_required")),
+        group: z.string().min(1, t("form.validation.group_required")),
+        instructor: z
+          .array(z.string())
+          .min(1, t("form.validation.instructor_required")),
+        startTime: z.string().min(1, t("form.validation.start_time_required")),
+      }),
+    [t]
+  );
 
   const form = useForm({
     defaultValues: {
@@ -375,7 +384,7 @@ export function CourseVaulForm() {
                       aria-invalid={isInvalid}
                       id={field.name}
                       onBlur={field.handleBlur}
-                      placeholder="Add instructor..."
+                      placeholder={t("course.add_instructor")}
                     />
                   </TagsInputList>
                 </TagsInput>

--- a/apps/web/src/components/header/dropdown.tsx
+++ b/apps/web/src/components/header/dropdown.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { BookOpen, Calendar, Menu, Monitor, Moon, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useTheme } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
@@ -20,17 +21,17 @@ const themes = [
   {
     icon: Monitor,
     key: "system",
-    label: "System theme",
+    translationKey: "theme.system",
   },
   {
     icon: Sun,
     key: "light",
-    label: "Light theme",
+    translationKey: "theme.light",
   },
   {
     icon: Moon,
     key: "dark",
-    label: "Dark theme",
+    translationKey: "theme.dark",
   },
 ];
 
@@ -39,6 +40,7 @@ function isTheme(value: unknown): value is "system" | "light" | "dark" {
 }
 
 export function ThemeDropdown() {
+  const { t } = useTranslation();
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
@@ -57,7 +59,7 @@ export function ThemeDropdown() {
     <DropdownMenu>
       <DropdownMenuTrigger>
         <Button
-          aria-label="Menu"
+          aria-label={t("nav.menu")}
           className="size-8 rounded-full p-0"
           size="icon"
           type="button"
@@ -71,19 +73,19 @@ export function ThemeDropdown() {
           <DropdownMenuItem>
             <Link className="flex w-full cursor-pointer gap-2.5" to="/courses">
               <BookOpen className="size-4" />
-              <span>Courses</span>
+              <span>{t("nav.courses")}</span>
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem>
             <Link className="flex w-full cursor-pointer gap-2.5" to="/schedule">
               <Calendar className="size-4" />
-              <span>Schedule</span>
+              <span>{t("nav.schedule")}</span>
             </Link>
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Theme</DropdownMenuLabel>
+          <DropdownMenuLabel>{t("theme.label")}</DropdownMenuLabel>
           <DropdownMenuRadioGroup
             onValueChange={(value) => {
               if (isTheme(value)) {
@@ -92,10 +94,10 @@ export function ThemeDropdown() {
             }}
             value={currentTheme}
           >
-            {themes.map(({ key, icon: Icon, label }) => (
+            {themes.map(({ key, icon: Icon, translationKey }) => (
               <DropdownMenuRadioItem key={key} value={key}>
                 <Icon className="size-4" />
-                <span>{label}</span>
+                <span>{t(translationKey)}</span>
               </DropdownMenuRadioItem>
             ))}
           </DropdownMenuRadioGroup>

--- a/apps/web/src/components/language-switcher.tsx
+++ b/apps/web/src/components/language-switcher.tsx
@@ -30,14 +30,14 @@ export function LanguageSwitcher() {
             changeLanguage("en");
           }}
         >
-          English
+          {t("language.english")}
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => {
             changeLanguage("th");
           }}
         >
-          ไทย (Thai)
+          {t("language.thai")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/src/components/logo.tsx
+++ b/apps/web/src/components/logo.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
@@ -32,12 +33,8 @@ export interface LogoProps
   alt?: string;
 }
 
-export function Logo({
-  alt = "Tarang Rian KMUTT logo",
-  className,
-  size,
-  ...props
-}: LogoProps) {
+export function Logo({ alt, className, size, ...props }: LogoProps) {
+  const { t } = useTranslation();
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
@@ -50,11 +47,12 @@ export function Logo({
     mounted && resolvedTheme === "dark"
       ? "/static/logos/logo-full-dark.svg"
       : "/static/logos/logo-full-light.svg";
+  const imageAlt = alt ?? t("brand.logo_alt");
 
   return (
-    <Link aria-label="Go to home page" to="/">
+    <Link aria-label={t("nav.home")} to="/">
       <img
-        alt={alt}
+        alt={imageAlt}
         className={cn(logoVariants({ className, size }))}
         src={logoSrc}
         {...props}

--- a/apps/web/src/components/schedule/block.tsx
+++ b/apps/web/src/components/schedule/block.tsx
@@ -135,7 +135,8 @@ export function SessionBlock({
                   : "text-primary-foreground/80"
               }`}
             >
-              {session.start} - {session.end} ({durationHours}h)
+              {session.start} - {session.end}{" "}
+              {t("schedule.duration", { duration: durationHours })}
             </div>
           </div>
         </CourseVaul>

--- a/apps/web/src/components/schedule/draggable-block.tsx
+++ b/apps/web/src/components/schedule/draggable-block.tsx
@@ -1,5 +1,6 @@
 import { useDraggable } from "@dnd-kit/core";
 import { GripVertical } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 import { SessionBlock } from "@/components/schedule/block";
 import { getClassKey, getTimeSlotPosition } from "@/components/schedule/utils";
@@ -34,6 +35,7 @@ export function DraggableBlock({
   defaultEditMode = false,
   timeRange,
 }: DraggableBlockProps) {
+  const { t } = useTranslation();
   const classKey = getClassKey(session);
   const isCustom = session.type === "custom";
   const position = getTimeSlotPosition(session.start, session.end, timeRange);
@@ -83,7 +85,7 @@ export function DraggableBlock({
           style={{
             left: `${startOffset * 100}%`,
           }}
-          title="Drag to change start time"
+          title={t("schedule.resize_start")}
         />
       )}
 
@@ -118,7 +120,7 @@ export function DraggableBlock({
           style={{
             right: `calc(${(1 - startOffset - span) * 100}%)`,
           }}
-          title="Drag to change end time"
+          title={t("schedule.resize_end")}
         />
       )}
 

--- a/apps/web/src/components/schedule/export/export-dialog.tsx
+++ b/apps/web/src/components/schedule/export/export-dialog.tsx
@@ -68,15 +68,15 @@ export function ScheduleExportDialog({
 
   // Background Color Presets
   const BG_PRESETS = [
-    { name: "White", value: "#ffffff" },
-    { name: "Slate", value: "#e2e8f0" },
-    { name: "Blue", value: "#bfdbfe" },
-    { name: "Green", value: "#bbf7d0" },
-    { name: "Yellow", value: "#fef08a" },
-    { name: "Orange", value: "#fed7aa" },
-    { name: "Red", value: "#fecaca" },
-    { name: "Rose", value: "#fecdd3" },
-    { name: "Black", value: "#000000" },
+    { key: "white", value: "#ffffff" },
+    { key: "slate", value: "#e2e8f0" },
+    { key: "blue", value: "#bfdbfe" },
+    { key: "green", value: "#bbf7d0" },
+    { key: "yellow", value: "#fef08a" },
+    { key: "orange", value: "#fed7aa" },
+    { key: "red", value: "#fecaca" },
+    { key: "rose", value: "#fecdd3" },
+    { key: "black", value: "#000000" },
   ];
 
   async function handleExport(): Promise<void> {
@@ -113,10 +113,10 @@ export function ScheduleExportDialog({
           }
         }
       }
-      toast.success(t("export.success", "Schedule exported successfully!"));
+      toast.success(t("export.success"));
     } catch (error) {
       console.error(error);
-      toast.error(t("export.error", "Failed to export schedule"));
+      toast.error(t("export.error"));
     } finally {
       setIsExporting(false);
     }
@@ -126,17 +126,17 @@ export function ScheduleExportDialog({
     try {
       const jsonData = JSON.stringify(sessions, null, 2);
       await navigator.clipboard.writeText(jsonData);
-      toast.success(t("export.copySuccess", "JSON copied to clipboard"));
+      toast.success(t("export.copySuccess"));
     } catch (error) {
       console.error(error);
-      toast.error(t("export.copyError", "Failed to copy JSON to clipboard"));
+      toast.error(t("export.copyError"));
     }
   }
 
   return (
     <Dialog>
       <DialogTrigger
-        aria-label={t("export.button", "Export")}
+        aria-label={t("export.button")}
         className={cn(
           buttonVariants({ size: "sm", variant: "outline" }),
           triggerClassName
@@ -144,15 +144,13 @@ export function ScheduleExportDialog({
         disabled={sessions.length === 0}
       >
         <Download className="size-5 sm:size-4" />
-        <span className="hidden sm:inline">{t("export.button", "Export")}</span>
+        <span className="hidden sm:inline">{t("export.button")}</span>
       </DialogTrigger>
 
       <DialogContent className="flex max-h-[95vh] w-full max-w-[95vw] flex-col gap-0 overflow-hidden p-0 sm:rounded-lg lg:max-w-300">
         <DialogHeader className="shrink-0 border-b p-6 pb-2">
-          <DialogTitle>{t("export.title", "Export Schedule")}</DialogTitle>
-          <DialogDescription>
-            {t("export.description", "Customize and download your schedule.")}
-          </DialogDescription>
+          <DialogTitle>{t("export.title")}</DialogTitle>
+          <DialogDescription>{t("export.description")}</DialogDescription>
         </DialogHeader>
 
         <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
@@ -161,7 +159,7 @@ export function ScheduleExportDialog({
               <div className="relative flex h-full flex-col">
                 <div className="absolute top-4 right-4 z-10">
                   <Button
-                    aria-label={t("export.copyAriaLabel", "Copy JSON")}
+                    aria-label={t("export.copyAriaLabel")}
                     onClick={() => {
                       void handleCopyToClipboard();
                     }}
@@ -169,7 +167,7 @@ export function ScheduleExportDialog({
                     variant="outline"
                   >
                     <Copy className="mr-2 h-4 w-4" />
-                    {t("export.copy", "Copy")}
+                    {t("export.copy")}
                   </Button>
                 </div>
                 <pre className="h-full overflow-auto rounded-md border bg-background p-4 font-mono text-sm">
@@ -211,7 +209,7 @@ export function ScheduleExportDialog({
           <div className="flex w-full shrink-0 flex-col border-t bg-background lg:w-[320px] lg:border-t-0 lg:border-l">
             <div className="flex-1 space-y-6 overflow-y-auto p-6">
               <div className="space-y-3">
-                <Label>{t("export.format", "Format")}</Label>
+                <Label>{t("export.format")}</Label>
                 <div className="grid grid-cols-4 gap-2">
                   <Button
                     className="w-full"
@@ -259,7 +257,7 @@ export function ScheduleExportDialog({
               <Separator />
 
               <div className="space-y-3">
-                <Label>{t("export.appearance", "Appearance")}</Label>
+                <Label>{t("export.appearance")}</Label>
                 <div className="flex flex-col gap-2">
                   <Button
                     className="justify-between"
@@ -274,7 +272,7 @@ export function ScheduleExportDialog({
                       ) : (
                         <CalendarPlus2 className="h-4 w-4" />
                       )}
-                      {t("export.shorthand", "Short day name")}
+                      {t("export.shorthand")}
                     </span>
                     <span
                       className={
@@ -283,7 +281,7 @@ export function ScheduleExportDialog({
                           : "text-muted-foreground"
                       }
                     >
-                      {isShorthand ? "On" : "Off"}
+                      {isShorthand ? t("export.on") : t("export.off")}
                     </span>
                   </Button>
                   <Button
@@ -299,7 +297,7 @@ export function ScheduleExportDialog({
                       ) : (
                         <Sun className="h-4 w-4" />
                       )}
-                      {t("export.darkMode", "Dark Mode")}
+                      {t("export.darkMode")}
                     </span>
                     <span
                       className={
@@ -308,7 +306,7 @@ export function ScheduleExportDialog({
                           : "text-muted-foreground"
                       }
                     >
-                      {darkMode ? "On" : "Off"}
+                      {darkMode ? t("export.on") : t("export.off")}
                     </span>
                   </Button>
                   <Button
@@ -320,7 +318,7 @@ export function ScheduleExportDialog({
                   >
                     <span className="flex items-center gap-2">
                       <Grid className="h-4 w-4" />
-                      {t("export.background", "Background")}
+                      {t("export.background")}
                     </span>
                     <span
                       className={
@@ -329,7 +327,7 @@ export function ScheduleExportDialog({
                           : "text-muted-foreground"
                       }
                     >
-                      {showBackground ? "Show" : "Hide"}
+                      {showBackground ? t("export.show") : t("export.hide")}
                     </span>
                   </Button>
 
@@ -337,7 +335,7 @@ export function ScheduleExportDialog({
                     <div className="flex flex-col gap-2 rounded-md border p-3">
                       <div className="flex items-center justify-between">
                         <span className="font-medium text-muted-foreground text-xs">
-                          Color
+                          {t("export.color")}
                         </span>
                         <div className="group relative h-8 w-8 cursor-pointer overflow-hidden rounded-full border bg-linear-to-br from-indigo-100 via-purple-100 to-pink-100 ring-primary hover:ring-2">
                           <Palette className="pointer-events-none absolute top-1/2 left-1/2 z-10 h-4 w-4 -translate-x-1/2 -translate-y-1/2 text-muted-foreground transition-colors group-hover:text-foreground" />
@@ -346,30 +344,34 @@ export function ScheduleExportDialog({
                             onChange={(e) => {
                               setBgColor(e.target.value);
                             }}
-                            title="Custom Color"
+                            title={t("export.custom_color")}
                             type="color"
                             value={bgColor}
                           />
                         </div>
                       </div>
                       <div className="flex flex-wrap gap-1.5 pt-1">
-                        {BG_PRESETS.map((preset) => (
-                          <button
-                            aria-label={preset.name}
-                            className={cn(
-                              "h-6 w-6 rounded-full border transition-all hover:scale-110",
-                              bgColor === preset.value &&
-                                "ring-2 ring-primary ring-offset-1"
-                            )}
-                            key={preset.value}
-                            onClick={() => {
-                              setBgColor(preset.value);
-                            }}
-                            style={{ backgroundColor: preset.value }}
-                            title={preset.name}
-                            type="button"
-                          />
-                        ))}
+                        {BG_PRESETS.map((preset) => {
+                          const presetName = t(`export.colors.${preset.key}`);
+
+                          return (
+                            <button
+                              aria-label={presetName}
+                              className={cn(
+                                "h-6 w-6 rounded-full border transition-all hover:scale-110",
+                                bgColor === preset.value &&
+                                  "ring-2 ring-primary ring-offset-1"
+                              )}
+                              key={preset.value}
+                              onClick={() => {
+                                setBgColor(preset.value);
+                              }}
+                              style={{ backgroundColor: preset.value }}
+                              title={presetName}
+                              type="button"
+                            />
+                          );
+                        })}
                       </div>
                     </div>
                   )}
@@ -379,11 +381,11 @@ export function ScheduleExportDialog({
               <Separator />
 
               <div className="space-y-3">
-                <Label>{t("export.settings", "Settings")}</Label>
+                <Label>{t("export.settings")}</Label>
                 <div className="grid gap-3">
                   <div className="flex items-center justify-between">
                     <span className="text-muted-foreground text-sm">
-                      {t("export.padding", "Padding")}
+                      {t("export.padding")}
                     </span>
                     <Select
                       onValueChange={(val: string | null) => {
@@ -397,7 +399,7 @@ export function ScheduleExportDialog({
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="0">None</SelectItem>
+                        <SelectItem value="0">{t("export.none")}</SelectItem>
                         <SelectItem value="16">16px</SelectItem>
                         <SelectItem value="32">32px</SelectItem>
                         <SelectItem value="64">64px</SelectItem>
@@ -407,7 +409,7 @@ export function ScheduleExportDialog({
                   </div>
                   <div className="flex items-center justify-between">
                     <span className="text-muted-foreground text-sm">
-                      {t("export.scale", "Quality")}
+                      {t("export.scale")}
                     </span>
                     <Select
                       disabled={format === "pdf"}

--- a/apps/web/src/components/schedule/export/import-dialog.tsx
+++ b/apps/web/src/components/schedule/export/import-dialog.tsx
@@ -80,7 +80,7 @@ export function ScheduleImportDialog({
       const json: unknown = JSON.parse(value);
       setSessions(parseImportedSessions(json, term));
     } catch {
-      setError(t("import.invalid_format", "Invalid JSON format"));
+      setError(t("import.invalid_format"));
       setSessions([]);
     }
   }
@@ -100,7 +100,7 @@ export function ScheduleImportDialog({
       const json: unknown = JSON.parse(await file.text());
       setSessions(parseImportedSessions(json, term));
     } catch {
-      setError(t("import.invalid_format", "Invalid JSON format"));
+      setError(t("import.invalid_format"));
       setSessions([]);
     }
   }
@@ -112,11 +112,11 @@ export function ScheduleImportDialog({
 
     try {
       importSchedule(term, sessions, mode);
-      toast.success(t("import.success", "Schedule imported successfully!"));
+      toast.success(t("import.success"));
       setIsOpen(false);
       resetState();
     } catch {
-      toast.error(t("import.error", "Failed to import schedule"));
+      toast.error(t("import.error"));
     }
   }
 
@@ -142,22 +142,20 @@ export function ScheduleImportDialog({
       open={isOpen}
     >
       <DialogTrigger
-        aria-label={t("import.button", "Import")}
+        aria-label={t("import.button")}
         className={cn(
           buttonVariants({ size: "sm", variant: "outline" }),
           triggerClassName
         )}
       >
         <Upload className="size-5 sm:size-4" />
-        <span className="hidden sm:inline">{t("import.button", "Import")}</span>
+        <span className="hidden sm:inline">{t("import.button")}</span>
       </DialogTrigger>
 
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{t("import.title", "Import Schedule")}</DialogTitle>
-          <DialogDescription>
-            {t("import.description", "Import a schedule from a JSON file.")}
-          </DialogDescription>
+          <DialogTitle>{t("import.title")}</DialogTitle>
+          <DialogDescription>{t("import.description")}</DialogDescription>
         </DialogHeader>
 
         <Tabs
@@ -169,19 +167,19 @@ export function ScheduleImportDialog({
           value={activeTab}
         >
           <TabsList className="grid w-full grid-cols-2">
-            <TabsTab value="paste">{t("import.tabPaste", "Paste")}</TabsTab>
-            <TabsTab value="file">{t("import.tabFile", "File")}</TabsTab>
+            <TabsTab value="paste">{t("import.tabPaste")}</TabsTab>
+            <TabsTab value="file">{t("import.tabFile")}</TabsTab>
           </TabsList>
 
           <div className="mt-4 space-y-4">
             <TabsPanel className="space-y-2" value="paste">
-              <Label>{t("import.tabPaste", "Paste")}</Label>
+              <Label>{t("import.tabPaste")}</Label>
               <Textarea
                 className="max-h-64 min-h-32 overflow-y-auto font-mono text-sm"
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
                   handlePasteChange(e.target.value);
                 }}
-                placeholder={t("import.pastePlaceholder", "Paste JSON here...")}
+                placeholder={t("import.pastePlaceholder")}
                 value={pastedJson}
               />
               {error !== null && error !== "" && (
@@ -190,7 +188,7 @@ export function ScheduleImportDialog({
             </TabsPanel>
 
             <TabsPanel className="space-y-2" value="file">
-              <Label>{t("import.file", "File")}</Label>
+              <Label>{t("import.file")}</Label>
               <button
                 className={cn(
                   "flex h-32 w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-md border-2 border-muted-foreground/25 border-dashed bg-muted/30 transition-colors hover:border-primary/50 hover:bg-muted/50",
@@ -203,7 +201,7 @@ export function ScheduleImportDialog({
                 <span className="text-muted-foreground text-sm">
                   {fileName !== null && fileName !== ""
                     ? fileName
-                    : t("import.dropzone", "Click to select JSON file")}
+                    : t("import.dropzone")}
                 </span>
               </button>
               <input
@@ -224,14 +222,14 @@ export function ScheduleImportDialog({
               <>
                 <div className="rounded-md border bg-muted/30 p-3">
                   <p className="font-medium text-sm">
-                    {t("import.sessions_count", "{{count}} sessions found", {
+                    {t("import.sessions_count", {
                       count: sessions.length,
                     })}
                   </p>
                 </div>
 
                 <div className="space-y-2">
-                  <Label>{t("import.mode", "Import Mode")}</Label>
+                  <Label>{t("import.mode")}</Label>
                   <div className="grid grid-cols-2 gap-2">
                     <Button
                       className="w-full"
@@ -241,7 +239,7 @@ export function ScheduleImportDialog({
                       size="sm"
                       variant={mode === "replace" ? "default" : "outline"}
                     >
-                      {t("import.replace", "Replace")}
+                      {t("import.replace")}
                     </Button>
                     <Button
                       className="w-full"
@@ -251,19 +249,13 @@ export function ScheduleImportDialog({
                       size="sm"
                       variant={mode === "merge" ? "default" : "outline"}
                     >
-                      {t("import.merge", "Merge")}
+                      {t("import.merge")}
                     </Button>
                   </div>
                   <p className="text-muted-foreground text-xs">
                     {mode === "replace"
-                      ? t(
-                          "import.replace_hint",
-                          "Replace current schedule with imported data"
-                        )
-                      : t(
-                          "import.merge_hint",
-                          "Add imported sessions to current schedule"
-                        )}
+                      ? t("import.replace_hint")
+                      : t("import.merge_hint")}
                   </p>
                 </div>
               </>
@@ -273,12 +265,10 @@ export function ScheduleImportDialog({
 
         <DialogFooter>
           <DialogClose
-            render={
-              <Button variant="outline">{t("form.cancel", "Cancel")}</Button>
-            }
+            render={<Button variant="outline">{t("form.cancel")}</Button>}
           />
           <Button disabled={sessions.length === 0} onClick={handleImport}>
-            {t("import.confirm", "Import")}
+            {t("import.confirm")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/components/schedule/index.tsx
+++ b/apps/web/src/components/schedule/index.tsx
@@ -774,7 +774,7 @@ export function Schedule({ sessions, term, styles }: ScheduleProps) {
                 return (
                   <DroppableCell id={dropId} key={dropId}>
                     <div
-                      aria-label={`${day} ${time} - ${t("schedule.drag_to_create")}`}
+                      aria-label={`${t(`days_time.${day.toLowerCase()}`)} ${time} - ${t("schedule.drag_to_create")}`}
                       className="relative touch-none border-border border-r bg-background last:border-r-0"
                       onPointerDown={(e) => {
                         handlePointerDown(e, day, timeColIndex);

--- a/apps/web/src/components/schedule/selected-course-card.tsx
+++ b/apps/web/src/components/schedule/selected-course-card.tsx
@@ -123,7 +123,7 @@ export function SelectedCourseCard({ session }: SelectedCourseCardProps) {
         </button>
 
         <button
-          aria-label={isCustom ? t("form.save") : t("courses.view")}
+          aria-label={isCustom ? t("course.edit") : t("courses.view")}
           className={`flex items-center justify-center bg-primary text-primary-foreground transition-colors hover:bg-primary/90 ${!isCustom && courseSlug !== undefined && courseSlug !== "" ? "h-1/3" : "h-1/2"}`}
           onClick={isCustom ? handleEditClick : handleViewClick}
           type="button"

--- a/apps/web/src/components/theme-switcher.tsx
+++ b/apps/web/src/components/theme-switcher.tsx
@@ -1,6 +1,7 @@
 import { Monitor, Moon, Sun } from "lucide-react";
 import { motion } from "motion/react";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
@@ -9,17 +10,17 @@ const themes = [
   {
     icon: Monitor,
     key: "system",
-    label: "System theme",
+    translationKey: "theme.system",
   },
   {
     icon: Sun,
     key: "light",
-    label: "Light theme",
+    translationKey: "theme.light",
   },
   {
     icon: Moon,
     key: "dark",
-    label: "Dark theme",
+    translationKey: "theme.dark",
   },
 ];
 
@@ -28,6 +29,7 @@ export interface ThemeSwitcherProps {
 }
 
 export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
+  const { t } = useTranslation();
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
@@ -50,12 +52,12 @@ export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
         className
       )}
     >
-      {themes.map(({ key, icon: Icon, label }) => {
+      {themes.map(({ key, icon: Icon, translationKey }) => {
         const isActive = currentTheme === key;
 
         return (
           <button
-            aria-label={label}
+            aria-label={t(translationKey)}
             className="relative h-6 w-6 rounded-full"
             key={key}
             onClick={() => {

--- a/apps/web/src/components/wwwk.tsx
+++ b/apps/web/src/components/wwwk.tsx
@@ -1,5 +1,6 @@
 import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
+import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
 
@@ -29,15 +30,13 @@ export interface WwwkProps
   alt?: string;
 }
 
-export function Wwwk({
-  alt = "WWWK logo",
-  className,
-  size,
-  ...props
-}: WwwkProps) {
+export function Wwwk({ alt, className, size, ...props }: WwwkProps) {
+  const { t } = useTranslation();
+  const imageAlt = alt ?? t("brand.wwwk_logo_alt");
+
   return (
     <img
-      alt={alt}
+      alt={imageAlt}
       className={cn(wwwkVariants({ className, size }))}
       src="/static/logos/wwwk-logo.svg"
       {...props}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -9,12 +9,32 @@
     "nav": {
       "courses": "Courses",
       "schedule": "Schedule",
-      "selected_classes": "Selected Classes"
+      "selected_classes": "Selected Classes",
+      "menu": "Menu",
+      "home": "Go to home page"
+    },
+    "theme": {
+      "label": "Theme",
+      "system": "System theme",
+      "light": "Light theme",
+      "dark": "Dark theme"
+    },
+    "language": {
+      "english": "English",
+      "thai": "ไทย (Thai)"
     },
     "form": {
       "save": "Save",
       "saving": "Saving...",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "validation": {
+        "course_code_required": "Course code is required.",
+        "course_name_required": "Course name is required.",
+        "end_time_required": "End time is required.",
+        "group_required": "Group is required.",
+        "instructor_required": "At least one instructor is required.",
+        "start_time_required": "Start time is required."
+      }
     },
     "days_time": {
       "day": "Day",
@@ -71,7 +91,10 @@
       "remove_from_schedule_description1": "Are you sure you want to remove",
       "remove_from_schedule_description2": "from your schedule? This action cannot be undone.",
       "remove": "Remove",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "resize_start": "Drag to change start time",
+      "resize_end": "Drag to change end time",
+      "duration": "({{duration}}h)"
     },
     "not_found": {
       "title": "Sorry!",
@@ -102,7 +125,14 @@
       "course_code": "Course Code",
       "course_name": "Course Name",
       "group": "Group",
-      "instructor": "Instructor"
+      "instructor": "Instructor",
+      "edit": "Edit course information",
+      "overlaps": "Overlaps:",
+      "add_instructor": "Add instructor..."
+    },
+    "brand": {
+      "logo_alt": "Tarang Rian KMUTT logo",
+      "wwwk_logo_alt": "WWWK logo"
     },
     "settings": {
       "title": "Settings",
@@ -154,7 +184,25 @@
       "copy": "Copy",
       "copyAriaLabel": "Copy JSON",
       "copySuccess": "JSON copied to clipboard",
-      "copyError": "Failed to copy JSON to clipboard"
+      "copyError": "Failed to copy JSON to clipboard",
+      "on": "On",
+      "off": "Off",
+      "show": "Show",
+      "hide": "Hide",
+      "color": "Color",
+      "custom_color": "Custom Color",
+      "none": "None",
+      "colors": {
+        "white": "White",
+        "slate": "Slate",
+        "blue": "Blue",
+        "green": "Green",
+        "yellow": "Yellow",
+        "orange": "Orange",
+        "red": "Red",
+        "rose": "Rose",
+        "black": "Black"
+      }
     },
     "import": {
       "title": "Import Schedule",

--- a/apps/web/src/locales/th/translation.json
+++ b/apps/web/src/locales/th/translation.json
@@ -9,12 +9,32 @@
     "nav": {
       "courses": "รายวิชา",
       "schedule": "ตารางเรียน",
-      "selected_classes": "รายวิชาที่เลือก"
+      "selected_classes": "รายวิชาที่เลือก",
+      "menu": "เมนู",
+      "home": "ไปยังหน้าหลัก"
+    },
+    "theme": {
+      "label": "ธีม",
+      "system": "ธีมระบบ",
+      "light": "ธีมสว่าง",
+      "dark": "ธีมมืด"
+    },
+    "language": {
+      "english": "อังกฤษ",
+      "thai": "ไทย"
     },
     "form": {
       "save": "บันทึก",
       "saving": "กำลังบรรทึก...",
-      "cancel": "ยกเลิก"
+      "cancel": "ยกเลิก",
+      "validation": {
+        "course_code_required": "กรุณาระบุรหัสวิชา",
+        "course_name_required": "กรุณาระบุชื่อวิชา",
+        "end_time_required": "กรุณาระบุเวลาสิ้นสุด",
+        "group_required": "กรุณาระบุกลุ่ม",
+        "instructor_required": "กรุณาระบุผู้สอนอย่างน้อยหนึ่งคน",
+        "start_time_required": "กรุณาระบุเวลาเริ่มต้น"
+      }
     },
     "days_time": {
       "day": "วัน",
@@ -71,7 +91,10 @@
       "remove_from_schedule_description1": "คุณแน่ใจหรือไม่ว่าต้องการลบ",
       "remove_from_schedule_description2": "ออกจากตารางเรียนของคุณ? การดำเนินการนี้จะไม่สามารถย้อนกลับได้ในภายหลัง",
       "remove": "ลบ",
-      "cancel": "ยกเลิก"
+      "cancel": "ยกเลิก",
+      "resize_start": "ลากเพื่อเปลี่ยนเวลาเริ่มต้น",
+      "resize_end": "ลากเพื่อเปลี่ยนเวลาสิ้นสุด",
+      "duration": "({{duration}} ชม.)"
     },
     "not_found": {
       "title": "ขออภัย!",
@@ -102,7 +125,14 @@
       "course_code": "รหัสวิชา",
       "course_name": "ชื่อวิชา",
       "group": "กลุ่ม",
-      "instructor": "ผู้สอน"
+      "instructor": "ผู้สอน",
+      "edit": "แก้ไขข้อมูลรายวิชา",
+      "overlaps": "ตารางเรียนชนกัน:",
+      "add_instructor": "เพิ่มผู้สอน..."
+    },
+    "brand": {
+      "logo_alt": "โลโก้ Tarang Rian KMUTT",
+      "wwwk_logo_alt": "โลโก้ WWWK"
     },
     "settings": {
       "title": "ตั้งค่าตารางเรียน",
@@ -154,7 +184,25 @@
       "copy": "คัดลอก",
       "copyAriaLabel": "คัดลอก JSON",
       "copySuccess": "คัดลอก JSON ไปยังคลิปบอร์ดแล้ว",
-      "copyError": "ไม่สามารถคัดลอก JSON ไปยังคลิปบอร์ดได้"
+      "copyError": "ไม่สามารถคัดลอก JSON ไปยังคลิปบอร์ดได้",
+      "on": "เปิด",
+      "off": "ปิด",
+      "show": "แสดง",
+      "hide": "ซ่อน",
+      "color": "สี",
+      "custom_color": "สีที่กำหนดเอง",
+      "none": "ไม่มี",
+      "colors": {
+        "white": "ขาว",
+        "slate": "สเลต",
+        "blue": "น้ำเงิน",
+        "green": "เขียว",
+        "yellow": "เหลือง",
+        "orange": "ส้ม",
+        "red": "แดง",
+        "rose": "กุหลาบ",
+        "black": "ดำ"
+      }
     },
     "import": {
       "title": "นำเข้าตารางเรียน",


### PR DESCRIPTION
## Description

Translate remaining app-owned labels and accessibility text across course, schedule, navigation, theme, import, and export interfaces.

## Type of Change

- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Code style changes (formatting, missing semicolons, etc.)
- [ ] refactor: Code refactoring without changing functionality
- [ ] perf: Performance improvements
- [ ] test: Adding or updating tests
- [ ] chore: Changes to build process, dependencies, or tooling
- [ ] ci: Changes to CI/CD configuration

## Changes Made

- Replaced hardcoded UI labels, placeholders, aria labels, titles, validation messages, and status text with translation keys.
- Added matching English and Thai translations for navigation, themes, languages, forms, course details, schedule controls, branding, import, and export features.
- Localized schedule day names in drag-to-create accessibility labels.
- Preserved custom logo alt text overrides while providing translated defaults.

## Testing

- [ ] I have tested this locally
- [ ] I have verified the changes work as expected
- [ ] I have checked for any console errors or warnings

## Checklist

- [ ] My code follows the project's code style (Ultracite standards)
- [ ] I have run `bun run fix` and it passes
- [ ] I have run `bun run check-types` and it passes
- [ ] I have run `bun run build` and it succeeds
- [x] I have removed all `console.log` and `debugger` statements
- [x] I have used explicit TypeScript types (no `any`)
- [x] My changes are properly typed
- [ ] I have updated documentation if needed
- [x] My commit message follows the conventional commit format
- [ ] I have tested in the relevant environment (browser, etc.)

## Related Issues

Closes #

## Screenshots / Demo

Not applicable.

## Additional Notes

Both English and Thai locale files were updated together to keep translation keys synchronized.